### PR TITLE
[t163020] Fix login screen when no saml_providers

### DIFF
--- a/auth_saml/views/auth_saml.xml
+++ b/auth_saml/views/auth_saml.xml
@@ -21,7 +21,7 @@
     </template>
     <template id="auth_saml.login" inherit_id="web.login" name="Samlv2 Login buttons">
         <xpath expr="//form" position="before">
-            <t t-set="form_small" t-value="len(saml_providers) &gt; 2" />
+            <t t-set="form_small" t-value="len(saml_providers or []) &gt; 2" />
         </xpath>
         <xpath expr="//div[hasclass('o_login_auth')]" position="inside">
             <t t-call="auth_saml.providers" />


### PR DESCRIPTION
In v15 the fix was applied in two places of the template, in v18 it's needed only in one.. Seems like progress :smiley: 

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=163020">[t163020] Check why URL without /odoo lead to maintenance page</a></li>
</ul>
<!-- BT_AUTOLINKS_END -->